### PR TITLE
Covert signature to hex before creating extrinsic

### DIFF
--- a/payctl/payctl.py
+++ b/payctl/payctl.py
@@ -133,7 +133,7 @@ def cmd_pay(args, config):
         call=call,
         keypair=keypair,
         nonce=account_info['nonce'],
-        signature=signature
+        signature=signature.hex()
     )
 
     print(

--- a/payctl/twitter.py
+++ b/payctl/twitter.py
@@ -17,7 +17,7 @@ class Twitter():
         api = tweepy.API(self.auth)
         try:
             api.update_status(status=text) 
-        except tweepy.error.TweepError as e:
+        except Exception as e:
             print('Update twitter status failed: ' + str(e))
 
     @staticmethod


### PR DESCRIPTION
Of some reason, it started to fail because the create_signed_extrinsic wants a str and not bytes. And the signature we get is in bytes.
I have created an Issue for it https://github.com/polkascan/py-substrate-interface/issues/215
